### PR TITLE
refactor: structopt to clap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /assets/mermaid*
 /assets/SourceHanSansJP*
 /samples
+/package-lock.json
+/package.json
+/node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,15 +268,51 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
- "bitflags",
- "textwrap",
- "unicode-width",
- "yaml-rust",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "constant_time_eq"
@@ -599,12 +684,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -763,6 +845,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,14 +931,14 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mermaid-cli-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "camino",
+ "clap",
  "headless_chrome",
  "mime",
  "reqwest",
- "structopt",
  "tokio",
 ]
 
@@ -1048,30 +1142,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1446,30 +1516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,15 +1560,6 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1732,18 +1769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1807,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"
@@ -2113,12 +2144,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-cli-rs"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["0x6b"]
 description = "Convert Mermaid diagram to PNG or SVG format."
@@ -14,9 +14,9 @@ path = "src/main.rs"
 [dependencies]
 axum = "0.6.7"
 camino = "1.0.7"
+clap = { version = "4.3.4", features = ["derive"] }
 headless_chrome = { version = "1.0.5", features = ["fetch"] }
 mime = "0.3.16"
-structopt = { version = "0.3.26", default_features = false, features = ["doc"] }
 tokio = { version = "1.17.0", features = ["full"] }
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -17,23 +17,20 @@ $ cargo install https://github.com/0x6b/mermaid-cli-rs
 The CLI supports the following command-line options:
 
 ```
-USAGE:
-    mmdc [OPTIONS] --input <diagram> --output <output>
+Convert Mermaid diagram to PNG or SVG format.
 
-FLAGS:
-        --help       Prints help information
-    -V, --version    Prints version information
+Usage: mmdc [OPTIONS] --input <DIAGRAM> --output <OUTPUT>
 
-OPTIONS:
-    -C, --configFile <config>    Path to a JSON configuration file for Mermaid
-    -i, --input <diagram>        Path to the Mermaid diagram file
-    -f, --font <font>            Path to a font file for Mermaid
-    -h, --height <height>        Height of the output image in pixels. This value is automatically reduced to fit the
-                                 image [default: 2160]
-    -o, --output <output>        Path to the output file. By default, the file format is PNG. Use a `.svg` extension for
-                                 an SVG file
-    -c, --cssFile <style>        Path to a CSS file for the HTML page
-    -w, --width <width>          Width of the output image in pixels [default: 1960]
+Options:
+  -i, --input <DIAGRAM>      Path to the Mermaid diagram file. Specify `-` for stdin
+  -o, --output <OUTPUT>      Path to the output file. By default, the file format is PNG. Specify a `.svg` extension if you need an SVG file
+  -w, --width <WIDTH>        Width of the output image in pixels [default: 1960]
+  -H, --height <HEIGHT>      Height of the output image in pixels. This value is automatically reduced to fit the image [default: 2160]
+  -c, --cssFile <STYLE>      Path to a CSS file for the HTML page
+  -C, --configFile <CONFIG>  Path to a JSON configuration file for Mermaid
+  -f, --font <FONT>          Path to a font file for Mermaid
+  -h, --help                 Print help
+  -V, --version              Print version
 ```
 
 ### Benchmark

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ use axum::{
     Router, Server,
 };
 use camino::Utf8PathBuf;
+use clap::Parser;
 use headless_chrome::{protocol::cdp::Page::CaptureScreenshotFormatOption::Png, Browser, LaunchOptionsBuilder};
 use mime::{APPLICATION_JSON, FONT_WOFF, TEXT_CSS_UTF_8, TEXT_HTML, TEXT_JAVASCRIPT, TEXT_PLAIN_UTF_8};
-use structopt::StructOpt;
 
 use crate::{
     macros::response,
@@ -50,7 +50,7 @@ async fn main() {
         width,
         height,
         output,
-    } = Args::from_args();
+    } = Args::parse();
 
     // A shared storage for resources used to serve.
     let shared_store = Arc::new(RwLock::new(Store {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,38 +1,37 @@
 use std::sync::{Arc, RwLock};
 
 use camino::Utf8PathBuf;
-use structopt::StructOpt;
+use clap::Parser;
 
-/// Command-line arguments for the `mermaid-cli-rs`.
-#[derive(StructOpt)]
-#[structopt(name = "mermaid-cli-rs", about = "Convert Mermaid diagram to PNG or SVG format.")]
+#[derive(Parser, Debug)]
+#[clap(about, version)]
 pub(crate) struct Args {
     /// Path to the Mermaid diagram file. Specify `-` for stdin.
-    #[structopt(short = "i", long = "input")]
+    #[arg(short = 'i', long = "input")]
     pub(crate) diagram: String,
 
     /// Path to the output file. By default, the file format is PNG. Specify a `.svg` extension if you need an SVG file.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub(crate) output: String,
 
     /// Width of the output image in pixels.
-    #[structopt(short, long, default_value = "1960")]
+    #[arg(short, long, default_value = "1960")]
     pub(crate) width: u32,
 
     /// Height of the output image in pixels. This value is automatically reduced to fit the image.
-    #[structopt(short, long, default_value = "2160")]
+    #[arg(short = 'H', long, default_value = "2160")]
     pub(crate) height: u32,
 
     /// Path to a CSS file for the HTML page.
-    #[structopt(short = "c", long = "cssFile")]
+    #[arg(short = 'c', long = "cssFile")]
     pub(crate) style: Option<String>,
 
     /// Path to a JSON configuration file for Mermaid.
-    #[structopt(short = "C", long = "configFile")]
+    #[arg(short = 'C', long = "configFile")]
     pub(crate) config: Option<String>,
 
     /// Path to a font file for Mermaid.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     pub(crate) font: Option<String>,
 }
 


### PR DESCRIPTION
- feat: use clap instead of structopt
- chore: ignore node dependencies
